### PR TITLE
phpunit を composer 経由でインストールできる環境を作った

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM php:7.0-apache
+WORKDIR /var/www/html/
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN apt-get update
+RUN apt-get install git unzip -y

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+  "require-dev": {
+    "phpunit/phpunit": "5.5.*"
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   apache-php7:
-    image: php:7.0-apache
+    build: .
     ports:
       - "80:80"
     volumes:


### PR DESCRIPTION
``` sh
docker exec -it piccolle_apache-php7_1 composer install
```

で phpunit のインストールができるようになります。
